### PR TITLE
fix: 메모 수정 이후 메인화면 메모 목록에 수정된 메모가 뜨지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/example/memousingroomdb/DetailMemoFragment.kt
+++ b/app/src/main/java/com/example/memousingroomdb/DetailMemoFragment.kt
@@ -23,7 +23,7 @@ class DetailMemoFragment : Fragment() {
 
     private var _binding: FragmentDetailMemoBinding? = null
     private val binding get() = _binding!!
-    var memo: Memo? = null
+    private var memo: Memo? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -37,28 +37,31 @@ class DetailMemoFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val db = MemoDatabase.getInstance(requireContext())
-        sharedViewModel.resultMemo.observe(viewLifecycleOwner) { result ->
+        parentFragmentManager.setFragmentResultListener(
+            "UpdateMemoFragment",
+            this
+        ) { requestKey, bundle ->
+            val isFromUpdateMemoFragment = bundle.getBoolean("IsUpdateMemoFragment")
+            if (isFromUpdateMemoFragment) {
+                sharedViewModel.resultMemo.observe(viewLifecycleOwner) { result ->
 
-            binding.tvMemoTitle.text = result.title
-            binding.tvMemoDate.text = result.date
-            if (result.content.isBlank()) {
-                binding.tvMemoContent.text = "내용이 없습니다."
-            } else {
-                binding.tvMemoContent.text = result.content
+                    binding.tvMemoTitle.text = result.title
+                    binding.tvMemoDate.text = result.date
+                    if (result.content.isBlank()) {
+                        binding.tvMemoContent.text = "내용이 없습니다."
+                    } else {
+                        binding.tvMemoContent.text = result.content
+                    }
+                    memo = result
+
+                }
             }
-            memo = result
-
         }
-
-
-
         memo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             arguments?.getSerializable("clickedMemo", Memo::class.java)
         } else {
             arguments?.getSerializable("clickedMemo") as? Memo
         }
-
 
         if (memo != null) {
             binding.tvMemoTitle.text = memo!!.title
@@ -74,16 +77,13 @@ class DetailMemoFragment : Fragment() {
             sharedViewModel.delete(memo!!)
             Toast.makeText(requireContext(), "메모가 지워졌어요", Toast.LENGTH_SHORT).show()
         }
-
         binding.btnMemoUpdate.setOnClickListener {
             val transaction = parentFragmentManager.beginTransaction()
             transaction.replace(R.id.fcv, UpdateMemoFragment.newInstance(memo!!))
             transaction.addToBackStack(null)
             transaction.commit()
         }
-
     }
-
     companion object {
         fun newInstance(memo: Memo): DetailMemoFragment {
             val fragment = DetailMemoFragment()
@@ -93,6 +93,4 @@ class DetailMemoFragment : Fragment() {
             return fragment
         }
     }
-
-
 }

--- a/app/src/main/java/com/example/memousingroomdb/DetailMemoFragment.kt
+++ b/app/src/main/java/com/example/memousingroomdb/DetailMemoFragment.kt
@@ -13,7 +13,6 @@ import androidx.fragment.app.FragmentTransaction
 import androidx.fragment.app.activityViewModels
 import com.example.memousingroomdb.databinding.FragmentDetailMemoBinding
 import com.example.memousingroomdb.db.Memo
-import com.example.memousingroomdb.db.MemoDao
 import com.example.memousingroomdb.db.MemoDatabase
 import java.time.LocalDate
 
@@ -72,8 +71,6 @@ class DetailMemoFragment : Fragment() {
         }
 
         binding.btnMemoDelete.setOnClickListener {
-            //db?.memoDao()?.deleteMemo(memo!!)
-            //sharedViewModel.deleteMemo(memo!!)
             sharedViewModel.delete(memo!!)
             Toast.makeText(requireContext(), "메모가 지워졌어요", Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/com/example/memousingroomdb/MainActivity.kt
+++ b/app/src/main/java/com/example/memousingroomdb/MainActivity.kt
@@ -2,6 +2,7 @@ package com.example.memousingroomdb
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -10,31 +11,21 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.memousingroomdb.databinding.ActivityMainBinding
 import com.example.memousingroomdb.db.Memo
-import com.example.memousingroomdb.db.MemoDatabase
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
     private val sharedViewModel: MemoSharedViewModel by viewModels()
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
-        val db = MemoDatabase.getInstance(this)
-
-        val intent = Intent(this,AddMemoActivity::class.java)
+        val intent = Intent(this, AddMemoActivity::class.java)
         val adapter = MemoAdapter()
-
-        sharedViewModel.memoList.observe(this){memos->
+        sharedViewModel.memoList.observe(this) { memos ->
             adapter.submitList(memos)
         }
-
-
-
-        //
         val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(
             ItemTouchHelper.UP or ItemTouchHelper.DOWN,
             ItemTouchHelper.LEFT
@@ -51,7 +42,8 @@ class MainActivity : AppCompatActivity() {
                 val position = viewHolder.adapterPosition
                 val memo = adapter.currentList[position]
                 // ViewModel에 삭제 요청
-                sharedViewModel.delete(memo)            }
+                sharedViewModel.delete(memo)
+            }
 
         }
         //
@@ -66,29 +58,26 @@ class MainActivity : AppCompatActivity() {
 
         val recyclerView = binding.rcvMemo
 
-        adapter.setOnItemClickListener(object : MemoAdapter.OnItemClickListener{
+        adapter.setOnItemClickListener(object : MemoAdapter.OnItemClickListener {
             override fun onItemClick(memo: Memo) {
                 val detailMemoFragment = DetailMemoFragment.newInstance(memo)
                 val transaction = supportFragmentManager.beginTransaction()
-                transaction.replace(R.id.fcv,detailMemoFragment)
+                transaction.replace(R.id.fcv, detailMemoFragment)
                 transaction.addToBackStack(null)
                 transaction.commit()
             }
         })
         recyclerView.layoutManager = LinearLayoutManager(this)
-        recyclerView.adapter=adapter
+        recyclerView.adapter = adapter
         observDeleteSignal(adapter)
 
     }
-    private fun observDeleteSignal(adapter:MemoAdapter){
-        sharedViewModel.deleteMemo.observe(this){memo->
+
+    private fun observDeleteSignal(adapter: MemoAdapter) {
+        sharedViewModel.deleteMemo.observe(this) { memo ->
             memo?.let {
                 supportFragmentManager.popBackStack()
                 adapter.deleteMemo(memo)
-//
-//                adapter.notifyItemRemoved(memoId)
-//                memoList?.removeAt(memoId)
-//                adapter.notifyDataSetChanged()
             }
         }
     }

--- a/app/src/main/java/com/example/memousingroomdb/MainActivity.kt
+++ b/app/src/main/java/com/example/memousingroomdb/MainActivity.kt
@@ -16,7 +16,6 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
     private val sharedViewModel: MemoSharedViewModel by viewModels()
-    private var memoList : MutableList<Memo>? = null
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,11 +24,14 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         val db = MemoDatabase.getInstance(this)
-        memoList = db?.memoDao()?.search()
 
         val intent = Intent(this,AddMemoActivity::class.java)
         val adapter = MemoAdapter()
-        adapter.submitList(memoList)
+
+        sharedViewModel.memoList.observe(this){memos->
+            adapter.submitList(memos)
+        }
+
 
 
         //

--- a/app/src/main/java/com/example/memousingroomdb/MemoSharedViewModel.kt
+++ b/app/src/main/java/com/example/memousingroomdb/MemoSharedViewModel.kt
@@ -12,8 +12,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class MemoSharedViewModel(application: Application): AndroidViewModel(application) {
+
     lateinit var memoList :LiveData<List<Memo>>
     val db = MemoDatabase.getInstance(application)
+    val allMemos: LiveData<List<Memo>> = db?.memoDao()!!.getAllMemosAsLiveData()
+
     init {
         if (db != null) {
             memoList=db.memoDao().getAllMemosAsLiveData()
@@ -38,5 +41,9 @@ class MemoSharedViewModel(application: Application): AndroidViewModel(applicatio
     }
     private val _deleteMemo = MutableLiveData<Memo?>()
     val deleteMemo: LiveData<Memo?> get() = _deleteMemo
+
+    fun getMemos(memo:Memo): MutableList<Memo>? {
+        return db?.memoDao()?.search()
+    }
 
 }

--- a/app/src/main/java/com/example/memousingroomdb/UpdateMemoFragment.kt
+++ b/app/src/main/java/com/example/memousingroomdb/UpdateMemoFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.example.memousingroomdb.databinding.FragmentUpdateMemoBinding
@@ -49,7 +50,6 @@ class UpdateMemoFragment : Fragment() {
 
         binding.btnMemoCancel.setOnClickListener {
             requireActivity().supportFragmentManager.popBackStack()
-
         }
 
         binding.btnMemoUpdate.setOnClickListener {
@@ -58,18 +58,20 @@ class UpdateMemoFragment : Fragment() {
                 title = binding.etTitle.text.toString(),
                 date = "${LocalDate.now()} 수정됨",
                 content = binding.etContent.text.toString(),
-                cnt=memo.cnt
+                cnt = memo.cnt
             )
-            if(memo.title == newMemo.title && memo.content == newMemo.content){
+            if (memo.title == newMemo.title && memo.content == newMemo.content) {
                 requireActivity().supportFragmentManager.popBackStack()
 
-            }
-            else{
+            } else {
                 db?.memoDao()?.updateMemo(newMemo)
                 sharedViewModel.updateMemo(newMemo)
+                parentFragmentManager.setFragmentResult(
+                    "UpdateMemoFragment",
+                    bundleOf("IsUpdateMemoFragment" to true)
+                )
                 requireActivity().supportFragmentManager.popBackStack()
             }
-
         }
     }
 
@@ -82,6 +84,4 @@ class UpdateMemoFragment : Fragment() {
             return fragment
         }
     }
-
-
 }


### PR DESCRIPTION
* DetailMemoFragment의 42~52째줄 코드(아래 참고)가 메모가 수정된 경우 수정을 감지하여 이후에 어떤 메모를 클릭하더라도 LIveData에 남아있는 데이터로 overwrite되는 문제가 발견하여 setFragmentResultListener를 이용하여 UpdateMemoFragment에서 온 경우에만 UI를 업데이트 하게 코드 변경

```kotlin
sharedViewModel.resultMemo.observe(viewLifecycleOwner) { result ->

            binding.tvMemoTitle.text = result.title
            binding.tvMemoDate.text = result.date
            if (result.content.isBlank()) {
                binding.tvMemoContent.text = "내용이 없습니다."
            } else {
                binding.tvMemoContent.text = result.content
            }
            memo = result
        }
```