### PR TITLE
fix: 메모1개를 지우고 다른 메모를 수정하다가 취소하는 경우 지운 메모가 뜨는 경우 해결

### DIFF
--- a/app/src/main/java/com/example/memousingroomdb/DetailMemoFragment.kt
+++ b/app/src/main/java/com/example/memousingroomdb/DetailMemoFragment.kt
@@ -47,7 +47,7 @@ class DetailMemoFragment : Fragment() {
 
                     binding.tvMemoTitle.text = result.title
                     binding.tvMemoDate.text = result.date
-                    if (result.content.isBlank()) {
+                    if (result.content.isEmpty()) {
                         binding.tvMemoContent.text = "내용이 없습니다."
                     } else {
                         binding.tvMemoContent.text = result.content
@@ -66,7 +66,7 @@ class DetailMemoFragment : Fragment() {
         if (memo != null) {
             binding.tvMemoTitle.text = memo!!.title
             binding.tvMemoDate.text = memo!!.date
-            if (memo!!.content.isBlank()) {
+            if (memo!!.content.isEmpty()) {
                 binding.tvMemoContent.text = "내용이 없습니다."
             } else {
                 binding.tvMemoContent.text = memo!!.content

--- a/app/src/main/java/com/example/memousingroomdb/UpdateMemoFragment.kt
+++ b/app/src/main/java/com/example/memousingroomdb/UpdateMemoFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -49,28 +50,57 @@ class UpdateMemoFragment : Fragment() {
         }
 
         binding.btnMemoCancel.setOnClickListener {
+
+            db?.memoDao()?.updateMemo(memo!!)
+            sharedViewModel.updateMemo(memo!!)
+            parentFragmentManager.setFragmentResult(
+                "UpdateMemoFragment",
+                bundleOf("IsUpdateMemoFragment" to true)
+            )
+
             requireActivity().supportFragmentManager.popBackStack()
         }
 
         binding.btnMemoUpdate.setOnClickListener {
-            val newMemo = Memo(
-                id = memo!!.id,
-                title = binding.etTitle.text.toString(),
-                date = "${LocalDate.now()} 수정됨",
-                content = binding.etContent.text.toString(),
-                cnt = memo.cnt
-            )
-            if (memo.title == newMemo.title && memo.content == newMemo.content) {
-                requireActivity().supportFragmentManager.popBackStack()
-
+            if (binding.etTitle.text.isBlank()) {
+                Toast.makeText(requireContext(), "제목을 입력해주세요.", Toast.LENGTH_SHORT).show()
             } else {
-                db?.memoDao()?.updateMemo(newMemo)
-                sharedViewModel.updateMemo(newMemo)
-                parentFragmentManager.setFragmentResult(
-                    "UpdateMemoFragment",
-                    bundleOf("IsUpdateMemoFragment" to true)
-                )
-                requireActivity().supportFragmentManager.popBackStack()
+
+                if (memo != null) {
+                    if (memo.title == binding.etTitle.text.toString() && memo.content == binding.etContent.text.toString()) {
+                        val newMemo = Memo(
+                            id = memo.id,
+                            title = binding.etTitle.text.toString(),
+                            date = memo.date,
+                            content = binding.etContent.text.toString(),
+                            cnt = memo.cnt
+                        )
+                        db?.memoDao()?.updateMemo(newMemo)
+                        sharedViewModel.updateMemo(newMemo)
+                        parentFragmentManager.setFragmentResult(
+                            "UpdateMemoFragment",
+                            bundleOf("IsUpdateMemoFragment" to true)
+                        )
+                        requireActivity().supportFragmentManager.popBackStack()
+
+                    } else {
+                        val newMemo = Memo(
+                            id = memo!!.id,
+                            title = binding.etTitle.text.toString(),
+                            date = "${LocalDate.now()} 수정됨",
+                            content = binding.etContent.text.toString(),
+                            cnt = memo.cnt
+                        )
+
+                        db?.memoDao()?.updateMemo(newMemo)
+                        sharedViewModel.updateMemo(newMemo)
+                        parentFragmentManager.setFragmentResult(
+                            "UpdateMemoFragment",
+                            bundleOf("IsUpdateMemoFragment" to true)
+                        )
+                        requireActivity().supportFragmentManager.popBackStack()
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
fix: 메모를 지우고 다른 메모 수정을 취소하는 경우 지운 메모가 간헐적으로 뜨는 경우가 발생하여 메모가 업데이트 할 필요가 없음에도 update로직을 적용하여 이전 메모가 뜨지 않게 해결.
fix: 메모 update에서 제목이 공백인데 업데이트 되는 것과 내용에 공백만 존재하는 경우 내용이 없다고 뜨는 버그 해